### PR TITLE
Fix onboarding flow

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'providers/habit_provider.dart';
 import 'screens/home_screen.dart';
+import 'screens/onboarding_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -10,13 +11,15 @@ void main() async {
   runApp(
     ChangeNotifierProvider(
       create: (context) => HabitProvider(prefs),
-      child: const MyApp(),
+      child: MyApp(prefs: prefs),
     ),
   );
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  final SharedPreferences prefs;
+
+  const MyApp({super.key, required this.prefs});
 
   @override
   Widget build(BuildContext context) {
@@ -37,7 +40,9 @@ class MyApp extends StatelessWidget {
         useMaterial3: true,
       ),
       themeMode: ThemeMode.system,
-      home: const HomeScreen(),
+      home: prefs.getBool('onboarding_complete') == true
+          ? const HomeScreen()
+          : const OnboardingScreen(),
     );
   }
 }

--- a/lib/screens/onboarding_features_screen.dart
+++ b/lib/screens/onboarding_features_screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'home_screen.dart';
 
 class OnboardingFeaturesScreen extends StatelessWidget {
   const OnboardingFeaturesScreen({super.key});
@@ -73,8 +75,17 @@ class OnboardingFeaturesScreen extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.all(16.0),
               child: ElevatedButton(
-                onPressed: () {
-                  // TODO: Implement Get Started action
+                onPressed: () async {
+                  final prefs = await SharedPreferences.getInstance();
+                  await prefs.setBool('onboarding_complete', true);
+                  if (context.mounted) {
+                    Navigator.of(context).pushAndRemoveUntil(
+                      MaterialPageRoute(
+                        builder: (_) => const HomeScreen(),
+                      ),
+                      (route) => false,
+                    );
+                  }
                 },
                 style: ElevatedButton.styleFrom(
                   backgroundColor: const Color(0xFF1993E5),

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'onboarding_features_screen.dart';
 
 class OnboardingScreen extends StatelessWidget {
   const OnboardingScreen({super.key});
@@ -60,7 +61,11 @@ class OnboardingScreen extends StatelessWidget {
               padding: const EdgeInsets.all(16.0),
               child: ElevatedButton(
                 onPressed: () {
-                  // TODO: Navigate to next screen
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const OnboardingFeaturesScreen()),
+                  );
                 },
                 style: ElevatedButton.styleFrom(
                   backgroundColor: const Color(0xFF1993E5),


### PR DESCRIPTION
## Summary
- connect onboarding screens to dashboard
- add get-started action
- show onboarding once based on stored flag

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687646714910832384d6560a5913a1da